### PR TITLE
Add animation index to Post Frame recording

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -407,6 +407,7 @@ This event will occur exactly once per frame per character (Ice Climbers are 2 c
 | 0x41 | Attack-based y Speed  | float | Negative means down, Positive means up | 3.5.0
 | 0x45 | Self-induced Ground x Speed  | float | Negative means left, Positive means right | 3.5.0
 | 0x49 | Hitlag frames remaining  | float | 0 means "not in hitlag" | 3.8.0
+| 0x4D | Animation Index | uint32 | Indicates the animation the character is in. For Wait: 2 = Wait1, 3 = Wait2, 4 = Wait3 | 3.11.0
 
 #### State Bit Flags 1
 Found in [Post-Frame Update](#post-frame-update).


### PR DESCRIPTION
Added Animation Index to Post Frame, so this updates the specs accordingly.

Accompanies the corresponding PR in `slippi-ssbm-asm`.