### PR TITLE
fix(spectator-protocol): remove trailing comma in example JSON

### DIFF
--- a/SPECTATOR_PROTOCOL.md
+++ b/SPECTATOR_PROTOCOL.md
@@ -28,7 +28,7 @@ The application layer protocol takes place entirely using JSON and is *mostly* s
 ```
 {
   "type": "connect_request",
-  "cursor": INTEGER,
+  "cursor": INTEGER
 }
 ```
 


### PR DESCRIPTION
I was wondering why my handshake wasn't getting through, but removing this trailing comma did the job :slightly_smiling_face:
