### PR TITLE
Document stage events

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -45,8 +45,8 @@ Every event is defined by a one byte code followed by a payload. The following t
 | [Frame Bookend](#frame-bookend) | 0x3C | An event that can be used to determine that the entire frame's worth of data has been transferred/processed | 3.0.0
 | Gecko List | 0x3D | An event that lists gecko codes. As it can be very large, the list is broken up into multiple messages | 3.3.0
 | [FOD Platforms](#fod-platforms) | 0x3F | This event records the height of Fountain of Dreams platforms | 3.17.0
-| [Whispy Blow Direction](#whispy-blow-direction) | 0x3F | This event records the direction that Whispy is blowing | 3.17.0
-| [Stadium Transformations](#stadium-transformations) | 0x3F | This event records the current Pokemon Stadium transformation | 3.17.0
+| [Whispy Blow Direction](#whispy-blow-direction) | 0x40 | This event records the direction that Whispy is blowing | 3.17.0
+| [Stadium Transformations](#stadium-transformations) | 0x41 | This event records the current Pokemon Stadium transformation | 3.17.0
 | [Message Splitter](#message-splitter) | 0x10 | A single part of a large message that has been split out. Currently only applies to Gecko List. | 3.3.0
 
 ### Data Types
@@ -543,30 +543,30 @@ The frame bookend is a simple event that can be used to determine that the entir
 | 0x5 | Latest Finalized Frame | int32 | For non-rollback, this should always equal the frame number. For rollback, this indicates the index of a frame which is guaranteed not to happen again (finalized). This is very useful when reading a file in real-time to make sure you are processing "finalized" information | 3.7.0
 
 ### FOD Platforms
-Only occurs when playing on Fountain of Dream, sent whenever the height of the platform changes.
+This event only occurs on Fountain of Dreams, and is sent every frame the height of the platform is changing.
 
 | Offset | Name | Type | Description | Added |
 | --- | --- | --- | --- | --- |
-| 0x0 | Command Byte | uint8 | (0x3C) The command byte for the FOD platform event | 3.17.0
+| 0x0 | Command Byte | uint8 | (0x3F) The command byte for the FOD platform event | 3.17.0
 | 0x1 | Frame Number | int32 | The number of the frame. Starts at -123. Frame 0 is when the timer starts counting down | 3.17.0
 | 0x5 | Platform | uint8 | Which platform has moved. (0 = Right, 1 = Left) | 3.17.0
 | 0x6 | Height | float | The platform's new height | 3.17.0
 
 ### Whispy Blow Direction
-Only occurs when playing on Dreamland 64, sent whenever Whispy changes blow directions.
+This event only occurs on Dreamland 64, and is sent whenever Whispy changes blow directions.
 
 | Offset | Name | Type | Description | Added |
 | --- | --- | --- | --- | --- |
-| 0x0 | Command Byte | uint8 | (0x3C) The command byte for the blow direction event | 3.17.0
+| 0x0 | Command Byte | uint8 | (0x40) The command byte for the blow direction event | 3.17.0
 | 0x1 | Frame Number | int32 | The number of the frame. Starts at -123. Frame 0 is when the timer starts counting down | 3.17.0
 | 0x5 | Direction | uint8 | Which direction Whispy is blowing (0 = None, 1 = Left, 2 = Right) | 3.17.0
 
 ### Stadium Transformations
-Only occurs when playing on Pokemon Stadium, sent whenever the transformation event changes.
+This event only occurs on Pokemon Stadium, and is sent whenever the transformation event changes.
 
 | Offset | Name | Type | Description | Added |
 | --- | --- | --- | --- | --- |
-| 0x0 | Command Byte | uint8 | (0x3C) The command byte for the blow direction event | 3.17.0
+| 0x0 | Command Byte | uint8 | (0x41) The command byte for the blow direction event | 3.17.0
 | 0x1 | Frame Number | int32 | The number of the frame. Starts at -123. Frame 0 is when the timer starts counting down | 3.17.0
 | 0x5 | Transformation Event | uint16 | The subevent for each transformation. (2 = Initialize, 3 = On monitor, 4 = Previous transformation receding, 5 = New transformation rising, 6 = Finalize, 0 = Finished) | 3.17.0
 | 0x7 | Transformation Type | uint16 | The current or upcoming transformation. (3 = Fire, 4 = Grass, 5 = Normal, 6 = Rock, 9 = Water) | 3.17.0

--- a/SPEC.md
+++ b/SPEC.md
@@ -44,6 +44,9 @@ Every event is defined by a one byte code followed by a payload. The following t
 | [Item Update](#item-update) | 0x3B | One event per frame per item with a maximum of 15 updates per frame. This information can be used for stats, training AIs, or visualization engines to handle items. Items include projectiles like lasers or needles | 3.0.0
 | [Frame Bookend](#frame-bookend) | 0x3C | An event that can be used to determine that the entire frame's worth of data has been transferred/processed | 3.0.0
 | Gecko List | 0x3D | An event that lists gecko codes. As it can be very large, the list is broken up into multiple messages | 3.3.0
+| [FOD Platforms](#fod-platforms) | 0x3F | This event records the height of Fountain of Dreams platforms | 3.17.0
+| [Whispy Blow Direction](#whispy-blow-direction) | 0x3F | This event records the direction that Whispy is blowing | 3.17.0
+| [Stadium Transformations](#stadium-transformations) | 0x3F | This event records the current Pokemon Stadium transformation | 3.17.0
 | [Message Splitter](#message-splitter) | 0x10 | A single part of a large message that has been split out. Currently only applies to Gecko List. | 3.3.0
 
 ### Data Types
@@ -538,6 +541,35 @@ The frame bookend is a simple event that can be used to determine that the entir
 | 0x0 | Command Byte | uint8 | (0x3C) The command byte for the frame bookend event | 3.0.0
 | 0x1 | Frame Number | int32 | The number of the frame. Starts at -123. Frame 0 is when the timer starts counting down | 3.0.0
 | 0x5 | Latest Finalized Frame | int32 | For non-rollback, this should always equal the frame number. For rollback, this indicates the index of a frame which is guaranteed not to happen again (finalized). This is very useful when reading a file in real-time to make sure you are processing "finalized" information | 3.7.0
+
+### FOD Platforms
+Only occurs when playing on Fountain of Dream, sent whenever the height of the platform changes.
+
+| Offset | Name | Type | Description | Added |
+| --- | --- | --- | --- | --- |
+| 0x0 | Command Byte | uint8 | (0x3C) The command byte for the FOD platform event | 3.17.0
+| 0x1 | Frame Number | int32 | The number of the frame. Starts at -123. Frame 0 is when the timer starts counting down | 3.17.0
+| 0x5 | Platform | uint8 | Which platform has moved. (0 = Right, 1 = Left) | 3.17.0
+| 0x6 | Height | float | The platform's new height | 3.17.0
+
+### Whispy Blow Direction
+Only occurs when playing on Dreamland 64, sent whenever Whispy changes blow directions.
+
+| Offset | Name | Type | Description | Added |
+| --- | --- | --- | --- | --- |
+| 0x0 | Command Byte | uint8 | (0x3C) The command byte for the blow direction event | 3.17.0
+| 0x1 | Frame Number | int32 | The number of the frame. Starts at -123. Frame 0 is when the timer starts counting down | 3.17.0
+| 0x5 | Direction | uint8 | Which direction Whispy is blowing (0 = None, 1 = Left, 2 = Right) | 3.17.0
+
+### Stadium Transformations
+Only occurs when playing on Pokemon Stadium, sent whenever the transformation event changes.
+
+| Offset | Name | Type | Description | Added |
+| --- | --- | --- | --- | --- |
+| 0x0 | Command Byte | uint8 | (0x3C) The command byte for the blow direction event | 3.17.0
+| 0x1 | Frame Number | int32 | The number of the frame. Starts at -123. Frame 0 is when the timer starts counting down | 3.17.0
+| 0x5 | Transformation Event | uint16 | The subevent for each transformation. (2 = Initialize, 3 = On monitor, 4 = Previous transformation receding, 5 = New transformation rising, 6 = Finalize, 0 = Finished) | 3.17.0
+| 0x7 | Transformation Type | uint16 | The current or upcoming transformation. (3 = Fire, 4 = Grass, 5 = Normal, 6 = Rock, 9 = Water) | 3.17.0
 
 ### Game End
 This event indicates the end of the game has occurred. This event will occur exactly once, as the last event in the stream. (Note: there is an unresolved bug where Game End doesn't appear in some replays!)

--- a/SPEC.md
+++ b/SPEC.md
@@ -543,7 +543,7 @@ The frame bookend is a simple event that can be used to determine that the entir
 | 0x5 | Latest Finalized Frame | int32 | For non-rollback, this should always equal the frame number. For rollback, this indicates the index of a frame which is guaranteed not to happen again (finalized). This is very useful when reading a file in real-time to make sure you are processing "finalized" information | 3.7.0
 
 ### FOD Platforms
-This event only occurs on Fountain of Dreams, and is sent every frame the height of the platform is changing.
+This event only occurs on Fountain of Dreams, and is sent for each change in platform height. If both platforms are moving, there will be two events per frame.
 
 | Offset | Name | Type | Description | Added |
 | --- | --- | --- | --- | --- |
@@ -562,7 +562,7 @@ This event only occurs on Dreamland 64, and is sent whenever Whispy changes blow
 | 0x5 | Direction | uint8 | Which direction Whispy is blowing (0 = None, 1 = Left, 2 = Right) | 3.17.0
 
 ### Stadium Transformations
-This event only occurs on Pokemon Stadium, and is sent whenever the transformation event changes.
+This event only occurs on Pokemon Stadium, and is sent whenever the transformation event or transformation type changes.
 
 | Offset | Name | Type | Description | Added |
 | --- | --- | --- | --- | --- |


### PR DESCRIPTION
for [this pr](https://github.com/project-slippi/slippi-ssbm-asm/pull/125) recording stage events.