### PR TITLE
Clarify windows replay spec

### DIFF
--- a/COMM_SPEC.md
+++ b/COMM_SPEC.md
@@ -6,7 +6,7 @@ This document will outline the details of the Slippi Dolphin communication file 
 | Name | Type | Description |
 | --- | --- | --- |
 | mode | string | Possible values are `normal` (default), `queue`, and `mirror` |
-| replay | string | The path to the replay if in normal or mirror mode |
+| replay | string | The path to the replay if in normal or mirror mode; for Windows, this path must be *relative to the json file* |
 | startFrame | int | The frame you would like to start the replay on, default is `-123` |
 | endFrame | int | The frame you would like to end the replay on, default is `INT_MAX` |
 | commandId | string | Typically used to indicate that the replay has changed, but updating the value can also restart playback of the current replay or queue |


### PR DESCRIPTION
When running on Windows with playback version 3.4.3 ([commit](https://github.com/project-slippi/Ishiiruka/commit/70328610bd751858d5677576dd3b2ebf9ced37a6)), if the path specified by `replay` is not either an absolute path or specified relative to the location *of the comm file*, the replay is never loaded. Can provide more logs and details if needed.